### PR TITLE
Update composer.json for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^8.1",
         "coderflex/laravel-turnstile": "^2.0",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^11.0",
+        "illuminate/contracts": "^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16.4"
     },
     "require-dev": {


### PR DESCRIPTION
Update composer.json to allow illuminate/contracts version 12 used in Laravel 12.